### PR TITLE
Adds empty-string as allowable value

### DIFF
--- a/javascript/jquery.uber-select.js
+++ b/javascript/jquery.uber-select.js
@@ -38,7 +38,7 @@
       $(select).on('uber-select:refresh change', updateSelectedValue)
 
       // When a result is selected
-      $(uberSearch).on('select', function(_, datum){
+      $(uberSearch).on('select', function(event, datum){
         updateSelectValue(datum.value)
       })
 

--- a/javascript/jquery.uber-select.js
+++ b/javascript/jquery.uber-select.js
@@ -38,7 +38,7 @@
       $(select).on('uber-select:refresh change', updateSelectedValue)
 
       // When a result is selected
-      $(uberSearch).on('select', function(event, datum){
+      $(uberSearch).on('select', function(_, datum){
         updateSelectValue(datum.value)
       })
 

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -122,8 +122,8 @@ var UberSearch = function(data, options){
   // HELPER FUNCTIONS
 
   function setData(newData){
-    data = newData
-    search.setData(setDataDefaults(data))
+    data = setDataDefaults(newData)
+    search.setData(data)
     updateSelectedText()
     markSelected()
   }
@@ -147,11 +147,9 @@ var UberSearch = function(data, options){
 
   // Inherit values for matchValue and value from text
   function setDataDefaults(data){
-    $.each(data, function(){
-      this.matchValue = this.matchValue || this.text
-      this.value = this.value || this.text
+    return $.map(data, function(datum) {
+      return $.extend({ value: datum.text, matchValue: datum.text }, datum)
     })
-    return data
   }
 
   // Converts the dataFromSelect into a datum list for matching


### PR DESCRIPTION
Since js attributes an empty string to a falsey value, we were overwritting it with the text. Resulting in unexpected behaviour where we cannot set default `value = ‘’`.  Sets defaults then overwrites them with the newData provided.