### PR TITLE
Select correct option after ajax list is created

### DIFF
--- a/javascript/jquery.uber-select.js
+++ b/javascript/jquery.uber-select.js
@@ -62,6 +62,7 @@
       if (options.dataUrl) {
         $.getJSON(options.dataUrl).done(function(data){
           $(select).append(optionsFromData(data))
+          updateSelectValue(options.value)
           uberSearch.setData(dataFromSelect(select))
           $(select).trigger(eventsTriggered.ready)
         })


### PR DESCRIPTION
After we grab the data from an endpoint, make sure to add the ‘selected’ attribute onto the option that corresponds to the select’s value (passed in with `options`)

Closes: https://github.com/culturecode/uber_select/issues/7