### PR TITLE
Make UI more keyboard navigable and add aria labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 UberSelect is a fancy UI on top of a regular `<select>` element.
 
 ## Requirements
+
 Tested on jQuery 1.11.x to 3.3.x
 
 ## Parts
+
 UberSelect is composed of two main parts, an UberSearch that does all the of searching and UI, and an UberSelect which
 is used to connect an UberSearch to a `<select>` element.
 
 ### UberSelect
+
 This is the object that allows an UberSearch and a `<select>` element to work together. The select element can be used
 to control the state of the UberSearch, and vice-versa. This means you can programmatically change the state of the
 select, and UberSearch will update. Users can interact with the UberSearch, and the select will update. This also means
@@ -22,38 +25,46 @@ $('.my_selects').uberSelect(options);
 ```
 
 #### Attributes <a name="UberSearch attributes"></a>
+
 Attribtes on the outermost element can be specified by setting the `data-uber-attributes` attribute on the `<select>` element. Values should be passed
 as a JSON string of key/value pairs where the key is the attribute name and the value is the attribute value.
 
 #### Options
+
 Options can be specified by setting the `data-uber-options` attribute on the `<select>` element. Values should be passed
 as a JSON string. All options on the are passed to the underlying UberSearch, see [UberSearch options](#UberSearchOptions).
 
 - ##### prepopulateSearchOnOpen
+
   Determines whether the search input starts with the selected value in it when the pane is opened.
 
   Default: `false`
 
 - ##### clearSearchClearsSelect
+
   Determines whether the select value should be cleared when the search is cleared.
 
   Default: `false`
 
 - ##### placeholder
+
   Placeholder to show in the selected text area.
 
   Default: `<select>` element attributes `<select placeholder="my placeholder" data-placeholder="my placeholder">`
 
 - ##### dataUrl
+
   A url to pre-fetch select options from. JSON response should be of the form
   `[{text:'option with explicit value', value: 'some value'}, {text:'option with implicit value'}]`. For a custom JSON response, use in conjunction with optionFromDatum.
 
   Default: `null`
 
 - ##### optionFromDatum
+
   A function that is used to customize the options value and text built from a JSON response. `datum` is a single result returned from the JSON response.
 
   The function signature is as follows:
+
   ```js
     function(datum) {
       return // a <option> element to represent the select
@@ -63,25 +74,36 @@ as a JSON string. All options on the are passed to the underlying UberSearch, se
    Default: `datum.value` populates the `<option>` value, `datum.text` populates the `<option>` text.
 
 - ##### value
+
   Initialize the UberSearch with this selected value
 
   Default: `<select>` element `value` property
 
+- ##### ariaLabel
+
+  Add an aria-label attribute with this value to the uber_select element.
+
 #### Events Triggered
+
 - ##### uber-select:ready
+
   This fires when the UberSelect has initialized and is ready for user interaction
 
 #### Events Observed
+
 The `<select>` element observes the following events:
 
 - ##### uber-select:refreshOptions
+
   The UberSearch options list will be updated to match the `<select>` element's `<option>` list.
 
 - ##### uber-select:refresh
+
   The UberSearch will update its selected value to match the `<select>` element's. This handler also runs when the
   `<select>` element triggers a `change` event.
 
 ### UberSearch
+
 The UberSearch performs all of the heavy lifting. It creates the UI views, maintains state, and performs the searching.
 It can be instantiated without the use of an UberSelect, which can be useful for situations where the selected value is
 being used in purely in JS, and not being linked to a `<select>` element in a form.
@@ -93,117 +115,143 @@ new UberSearch(data, options);
 ```
 
 #### Data
+
 Data is an array of objects. Each object may have the following properties:
 
 - ##### text
+
   String shown to the user in the list of results. This value is required if *value* is not provided.
 
 - ##### selectedText
+
   String shown to the user in the output container when this option is selected. *optional*
 
 - ##### title
+
   Title text shown to the user when hovering over the result. *optional*
 
 - ##### value
+
   This is matched against the *value* option passed UberSearch and will appear selected if it matches. It is also used to match against search input text when the user searches. This value is required if *text* is not provided.
 
 - ##### matchValue
+
   This overrides the value used to match against search input text when the user searches. *optional*
 
 - ##### visibility
+
   This is used to determine whether the option appears only when searching or only when not searching. Values accepted: `query`, `no-query`. *optional*
 
 - ##### disabled
+
   This is used to determine whether the option appears disabled. *optional*
 
 - ##### group
+
   This is used to visually group options. All options with the same group will appear together. *optional*
 
 #### Methods
 
 - ##### setData(data)
+
   Sets the data. `data` should be an Array conforming to the specifications described in <a href="#data">Data</a>
 
-
 #### Options <a name="UberSearch options"></a>
+
 Options can be specified by setting the `data-uber-options` attribute on the `<select>` element. Values should be passed
 as a JSON string.
 
 - ##### value
+
   Sets the initially selected value of the UberSearch. This value should match the `value` property of the desired
   option data.
 
   Default: `null`
 
 - ##### search
+
   Determines whether the search input be shown.
 
   Default: `true`
 
 - ##### clearSearchButton
+
   Sets the text content of clear search button.
 
   Default: `✕`
 
 - ##### selectCaret
+
   Sets the text content of clear select caret.
 
   Default: `⌄`
 
 - ##### hideBlankOption
+
   Sets whether blank options should be hidden automatically.
 
   Default: `false`
 
 - ##### treatBlankOptionAsPlaceholder
+
   Determines whether the `text` property of an option with a blank `value` property should be used as the placeholder
   text if no placeholder is specified.
 
   Default: `false`
 
 - ##### highlightByDefault
+
   Determines whether the first search result be auto-highlighted.
 
   Default: `true`
 
 - ##### minQueryLength
+
   Sets minimum number of characters the user must type before a search will be performed.
 
   Default: `0`
 
 - ##### minQueryMessage
+
   Sets the message shown to the user when the query doesn't exceed the minimum length. `true` for a default message,
   `false` for none, or provide a string to set a custom message.
 
   Default: `true`
 
 - ##### placeholder
+
   Sets the placeholder shown in the selected text area.
 
   Default: `null`
 
 - ##### searchPlaceholder
+
   Sets the placeholder shown in the search input.
 
   Default: `'Type to search'`
 
 - ##### noResultsText
+
   Sets the message shown when there are no results.
 
   Default: `'No Matches Found'`
 
 - ##### noDataText
+
   Sets the text to show when the results list is empty and no search is in progress
 
   Default: `'No options'`
   
 - ##### searchInputAttributes
+
   An Object containing attributes to add to the search input element.
 
 - ##### buildResult
+
   A function that is used to build result elements.
 
   The function signature is as follows:
+
   ```js
     function(listOptionData) {
       return // HTML/element to insert into the the results list
@@ -211,10 +259,12 @@ as a JSON string.
   ```
 
 - ##### resultPostprocessor
+
   A function that is run after a result is built and can be used to decorate it. This can be useful when extending the
   functionality of an existing UberSearch implementation.
 
   The function signature is as follows:
+
   ```js
     function(resultsListElement, listOptionData) { }
   ```
@@ -222,50 +272,63 @@ as a JSON string.
   Default: No-op
 
 - ##### onRender
+
   A function to run when the results container is rendered. If the result returns false, the default `select` event
   handler is not run and the event is cancelled.
 
   The function signature is as follows:
+
   ```js
   function(resultsContainer, searchResultsHTML) { }
   ```
 
 - ##### onSelect
+
   A function to run when a result is selected. If the result returns false, the default `select` event handler is not
   run and the event is cancelled.
 
   The function signature is as follows:
+
   ```js
   function(listOptionData, resultsListElement, clickEvent) { }
   ```
 
 - ##### onNoHighlightSubmit
+
   A function to run when a user presses enter without selecting a result.
   Should be used in combination with `highlightByDefault: false`.
 
   The function signature is as follows:
+
   ```js
   function(value) { }
   ```
 
 - ##### outputContainer (Deprecated)
+
   An object that receives the output once a result is selected. Must respond to `setValue(value)` and `view()`. This object serves to
   attach the result list to the DOM at the desired location.
 
 #### Events Triggered
+
 - ##### shown
+
   This fires when the UberSearch pane is opened.
 
 - ##### renderedResults
+
   This fires each time the list of results is updated.
 
 - ##### clear
+
   This fires when the user clicks the clear search button.
 
 - ##### select
+
   This fires when the user selects a result.
 
   The handler function signature is as follows:
+
   ```js
   function(event, [listOptionData, resultsContainer, originalEvent]) { }
   ```

--- a/javascript/jquery.uber-select.js
+++ b/javascript/jquery.uber-select.js
@@ -48,7 +48,6 @@
 
       // When a result is selected
       $(uberSearch).on('select', function(_, datum){
-        console.log("Result selected", datum)
         updateSelectValue(datum.value)
       })
 

--- a/javascript/jquery.uber-select.js
+++ b/javascript/jquery.uber-select.js
@@ -48,6 +48,7 @@
 
       // When a result is selected
       $(uberSearch).on('select', function(_, datum){
+        console.log("Result selected", datum)
         updateSelectValue(datum.value)
       })
 

--- a/javascript/list.js
+++ b/javascript/list.js
@@ -7,7 +7,8 @@ function List(options) {
   // BEHAVIOUR
 
   // Handle up and down arrow key presses
-  $(options.keypressInput).on('keydown', function(event){
+  $(options.keypressInput || view).on('keydown', function(event){
+    console.log("keydown", event.which)
     switch (event.which) {
       case 38: // Up Arrow
         stepHighlight(-1, true)
@@ -39,9 +40,12 @@ function List(options) {
   }
 
   this.renderResults = function(data){
+    console.log("List.prototype.renderResults", data)
     var results = $.map(data, function(datum){
       return context.buildResult(datum)
     })
+
+    console.log("renderResults results", results)
 
     view.toggleClass('empty', !data.length)
 
@@ -50,7 +54,8 @@ function List(options) {
 
   // Can be overridden to format how results are built
   this.buildResult = function(datum){
-    return $('<li></li>').html(datum).addClass('result')
+    var $link = $('<a href="#"></a>').html(datum)
+    return $('<li role="option" class="result" tabindex="0"></li>').html($link)
   }
 
   this.unhighlightResults = unhighlightResults
@@ -73,6 +78,7 @@ function List(options) {
     if (!result.length) { return }
 
     result.addClass('highlighted')
+    result.attr("aria-selected", true)
 
     if (options.scroll){
       scrollResultIntoView(result)
@@ -80,7 +86,7 @@ function List(options) {
   }
 
   function unhighlightResults(){
-    highlightedResult().removeClass('highlighted')
+    highlightedResult().removeClass('highlighted').attr("aria-selected", false)
   }
 
   function highlightedResult(){

--- a/javascript/list.js
+++ b/javascript/list.js
@@ -8,7 +8,6 @@ function List(options) {
 
   // Handle up and down arrow key presses
   $(options.keypressInput || view).on('keydown', function(event){
-    console.log("keydown", event.which)
     switch (event.which) {
       case 38: // Up Arrow
         stepHighlight(-1, true)

--- a/javascript/list.js
+++ b/javascript/list.js
@@ -39,12 +39,9 @@ function List(options) {
   }
 
   this.renderResults = function(data){
-    console.log("List.prototype.renderResults", data)
     var results = $.map(data, function(datum){
       return context.buildResult(datum)
     })
-
-    console.log("renderResults results", results)
 
     view.toggleClass('empty', !data.length)
 
@@ -53,8 +50,7 @@ function List(options) {
 
   // Can be overridden to format how results are built
   this.buildResult = function(datum){
-    var $link = $('<a href="#"></a>').html(datum)
-    return $('<li role="option" class="result" tabindex="0"></li>').html($link)
+    return $('<li role="option" class="result" tabindex="0"></li>').html(datum)
   }
 
   this.unhighlightResults = unhighlightResults

--- a/javascript/output_container.js
+++ b/javascript/output_container.js
@@ -1,6 +1,6 @@
 var OutputContainer = function(options){
   options = $.extend({}, options)
-  var view         = this.view = $('<span class="selected_text_container" tabindex="0"></span>')
+  var view         = $('<span class="selected_text_container" tabindex="0"></span>')
   var selectedText = $('<span class="selected_text"></span>').appendTo(view)
   var selectCaret  = $('<span class="select_caret"></span>').appendTo(view).html(options.selectCaret)
 

--- a/javascript/pane.js
+++ b/javascript/pane.js
@@ -3,40 +3,31 @@ function Pane(options){
     trigger: null
   }, options)
 
-  var context = this
-  var model = this.model = {}
-  var isOpen = false
-  var view = this.view = $('<div class="pane"></div>').toggle(isOpen)
+  var context   = this
+  var model     = {}
+  var isOpen    = false
+  var view      = $('<div class="pane"></div>').toggle(isOpen)
   var innerPane = $('<div class="pane_inner"></div>').appendTo(view)
 
 
   // PUBLIC INTERFACE
 
-  $.extend(this, {view: view, addContent: addContent, removeContent: removeContent, show: show, hide: hide})
+  $.extend(this, {
+    model:         model,
+    view:          view,
+    addContent:    addContent,
+    removeContent: removeContent,
+    show:          show,
+    hide:          hide,
+    toggle:        toggle,
+    isOpen:        paneIsOpen,
+    isClosed:      paneIsClosed
+  })
 
 
   // BEHAVIOUR
 
-  if (options.trigger){
-    // Show the pane when the select element is clicked
-    $(options.trigger).on('click', function(event){
-      if ($(options.trigger).hasClass('disabled')) { return }
-
-      context.show()
-    })
-
-    // Show the pane if the user was tabbed onto the trigger and pressed enter or space
-    $(options.trigger).on('keyup', function(event){
-      if ($(options.trigger).hasClass('disabled')) { return }
-
-      if (event.which == 13 || event.which == 32){
-        context.show()
-        return false
-      }
-    })
-  }
-
-    // Hide the pane when clicked out
+  // Hide the pane when clicked out
   $(document).on('mousedown', function(event){
     if (isEventOutsidePane(event) && isEventOutsideTrigger(event)){
       context.hide()
@@ -52,12 +43,20 @@ function Pane(options){
   $(document).on('keyup', function(event){
     if (event.which == 27 && isOpen){
       context.hide()
-      options.trigger.focus()
+      return false
     }
   })
 
 
   // HELPER FUNCTIONS
+
+  function paneIsOpen(){
+    return isOpen
+  }
+
+  function paneIsClosed(){
+    return !isOpen
+  }
 
   function addContent(name, content){
     model[name] = content
@@ -80,6 +79,10 @@ function Pane(options){
     isOpen = false
     view.hide()
     $(context).trigger('hidden')
+  }
+  function toggle(){
+    if (isOpen) context.hide()
+    else        context.show()
   }
 
   // returns true if the event originated outside the pane

--- a/javascript/pane.js
+++ b/javascript/pane.js
@@ -81,8 +81,11 @@ function Pane(options){
     $(context).trigger('hidden')
   }
   function toggle(){
-    if (isOpen) context.hide()
-    else        context.show()
+    if (isOpen) {
+      context.hide()
+    } else {
+      context.show()
+    }
   }
 
   // returns true if the event originated outside the pane

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -94,7 +94,7 @@ var UberSearch = function(data, options){
     if (options.search) {
       $(searchField.input).focus()
     } else {
-      pane.view.find("ul.results li:first > a").focus()
+      pane.view.find("ul.results li:first").focus()
     }
 
     triggerEvent(eventsTriggered.shown)
@@ -132,7 +132,6 @@ var UberSearch = function(data, options){
   // When a search result is chosen
   resultsContainer.on('click', '.result:not(.disabled)', function(event){
     var datum = $(this).data()
-    console.log("result chosen", datum)
 
     if (options.onSelect(datum, this, event) === false) {
       event.stopPropagation()
@@ -277,19 +276,16 @@ var UberSearch = function(data, options){
   }
 
   function buildResult(datum){
-    // var result = $('<li class="result"></li>')
-    //   .html((options.treatBlankOptionAsPlaceholder ? datum.text || options.placeholder : datum.text) || "&nbsp;")
-    //   .data(datum) // Store the datum so we can get know what the value of the selected item is
+    var result = $('<li class="result" tabindex="0"></li>')
+      .html((options.treatBlankOptionAsPlaceholder ? datum.text || options.placeholder : datum.text) || "&nbsp;")
+      .data(datum) // Store the datum so we can get know what the value of the selected item is
 
-    var $link   = $('<a href="#"></a>').html((options.treatBlankOptionAsPlaceholder ? datum.text || options.placeholder : datum.text) || "&nbsp;")
-    var $result = $('<li role="option" class="result" tabindex="0"></li>').html($link).data(datum)
+    if (datum.title) { result.attr('title', datum.title) }
+    if (datum.disabled) { result.addClass('disabled') }
 
-    if (datum.title) { $result.attr('title', datum.title) }
-    if (datum.disabled) { $result.addClass('disabled') }
+    options.resultPostprocessor(result, datum)
 
-    options.resultPostprocessor($result, datum)
-
-    return $result
+    return result
   }
 
   function markSelected(){


### PR DESCRIPTION
UberSelect.UberSearch (i.e. class="uber_select")
- Add ariaLabel option to the public interface that an arial-label to main element if provided
- Add role="listbox"
  (see <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role>)
- If search is disabled
  - Make keypressInput null
  - When pane is shown focus on first anchor tag in results list
  - Add anchor tags to each results element so that they can recieve focus
    (note: it's this "buildResult" function that actually get's called not UberSelect.List.prototype.buildResult below)

UberSelect.List
- If search is disabled use list element (i.e. class="results") for catching key press events
- Add anchors tag to each results element so that they can recieve focus
- Add the aria-selected attribute to results
- Add role="option" this is designed to work with role="listbox"
  (see <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/option_role>)