### PR TITLE
Prevent XSS by using `text()` instead of `html()`

### DIFF
--- a/javascript/output_container.js
+++ b/javascript/output_container.js
@@ -11,7 +11,8 @@ var OutputContainer = function(options){
   // HELPER FUNCTIONS
 
   function setValue(value){
-    selectedText.html(value || '&nbsp;')
+    selectedText.text(value || String.fromCharCode(160)); // Insert value or &nbsp;
+
     view.toggleClass('empty', !value)
   }
 

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -319,8 +319,10 @@ var UberSearch = function(data, options){
   }
 
   function buildResult(datum){
+    var text = (options.treatBlankOptionAsPlaceholder ? datum.text || options.placeholder : datum.text);
+
     var result = $('<li class="result" tabindex="-1"></li>') // Use -1 tabindex so that the result can be focusable but not tabbable.
-      .html((options.treatBlankOptionAsPlaceholder ? datum.text || options.placeholder : datum.text) || "&nbsp;")
+      .text(text || String.fromCharCode(160)) // Insert text or &nbsp;
       .data(datum) // Store the datum so we can get know what the value of the selected item is
 
     if (datum.title) { result.attr('title', datum.title) }


### PR DESCRIPTION
We don't want `<option>Sebastian&gt;script&lt;alert('pwned')&gt;/script&lt;</option>` to be turned into executable JS.