### PR TITLE
Update aria roles for uberselect

### DIFF
--- a/javascript/pane.js
+++ b/javascript/pane.js
@@ -7,7 +7,7 @@ function Pane(){
   var context   = this
   var model     = {}
   var isOpen    = false
-  var view      = $('<div class="pane"></div>').toggle(isOpen)
+  var view      = $('<div class="pane" role="listbox"></div>').toggle(isOpen)
   var innerPane = $('<div class="pane_inner"></div>').appendTo(view)
 
 

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -32,7 +32,7 @@ var UberSearch = function(data, options){
   }, options)
 
   var context          = this
-  var view             = $('<span class="uber_select" role="listbox"></span>')
+  var view             = $('<span class="uber_select"></span>')
   var selectedValue    = options.value // Internally selected value
   var outputContainer  = options.outputContainer || new OutputContainer({selectCaret: options.selectCaret})
   var resultsContainer = $('<div class="results_container"></div>')
@@ -321,7 +321,7 @@ var UberSearch = function(data, options){
   function buildResult(datum){
     var text = (options.treatBlankOptionAsPlaceholder ? datum.text || options.placeholder : datum.text);
 
-    var result = $('<li class="result" tabindex="-1"></li>') // Use -1 tabindex so that the result can be focusable but not tabbable.
+    var result = $('<li class="result" role="listitem" tabindex="-1"></li>') // Use -1 tabindex so that the result can be focusable but not tabbable.
       .text(text || String.fromCharCode(160)) // Insert text or &nbsp;
       .data(datum) // Store the datum so we can get know what the value of the selected item is
 


### PR DESCRIPTION
Move the listbox role down to the pane. Per the examples in the documentation, the select label is not included in the listbox.

Add listitem role to each list item so screen-readers know the options that are inside the select.

Reference for example of listbox html: https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-grouped/