### PR TITLE
5673 aria roles for uberselect

### DIFF
--- a/javascript/jquery.uber-select.js
+++ b/javascript/jquery.uber-select.js
@@ -186,7 +186,7 @@
       // Hide the select, but keep its width to allow it to set the min width of the uber select
       // NOTE: IE doesn't like 0 height, so give it 1px height and then offset
       function hideSelect(){
-        $(select).wrap($('<div>').css({visibility: 'hidden', height: '1px', marginTop: '-1px', pointerEvents: 'none'}).addClass('select_width_spacer'))
+        $(select).wrap($('<div>').css({visibility: 'hidden', height: '1px', marginTop: '-1px', pointerEvents: 'none'}).addClass('select_width_spacer').attr('aria-hidden', true))
       }
     })
 

--- a/javascript/list.js
+++ b/javascript/list.js
@@ -90,7 +90,6 @@ function List(options) {
     }
 
     result.addClass('highlighted')
-    result.attr("aria-selected", true)
 
     if (options.focus) {
       result.focus()
@@ -107,7 +106,7 @@ function List(options) {
     }, options)
 
     var result = highlightedResult()
-    result.removeClass('highlighted').attr("aria-selected", false)
+    result.removeClass('highlighted')
 
     if (options.blur) {
       result.blur()

--- a/javascript/output_container.js
+++ b/javascript/output_container.js
@@ -6,6 +6,7 @@ var OutputContainer = function(options){
 
   // INITIALIZATION
 
+  if (options.ariaLabel) { view.attr("aria-label", options.ariaLabel) }
   setValue()
 
   // HELPER FUNCTIONS
@@ -22,5 +23,5 @@ var OutputContainer = function(options){
 
   // PUBLIC INTERFACE
 
-  $.extend(this, {view: view, setValue: setValue, setDisabled: setDisabled })
+  $.extend(this, {view: view, setValue: setValue, setDisabled: setDisabled})
 }

--- a/javascript/output_container.js
+++ b/javascript/output_container.js
@@ -1,6 +1,6 @@
 var OutputContainer = function(options){
   options = $.extend({}, options)
-  var view         = $('<span class="selected_text_container" aria-expanded="false" aria-haspopup="listbox" role="combobox" tabindex="0"></span>')
+  var view         = $('<span class="selected_text_container" aria-expanded="false" aria-activedescendant aria-haspopup="listbox" role="combobox" tabindex="0"></span>')
   var selectedText = $('<span class="selected_text"></span>').appendTo(view)
   var selectCaret  = $('<span class="select_caret"></span>').appendTo(view).html(options.selectCaret)
 
@@ -9,13 +9,6 @@ var OutputContainer = function(options){
   setValue()
 
   // HELPER FUNCTIONS
-  function open() {
-    view.attr('aria-expanded', true)
-  }
-
-  function close() {
-    view.attr('aria-expanded', false)
-  }
 
   function setValue(value){
     selectedText.text(value || String.fromCharCode(160)); // Insert value or &nbsp;
@@ -29,5 +22,5 @@ var OutputContainer = function(options){
 
   // PUBLIC INTERFACE
 
-  $.extend(this, {view: view, setValue: setValue, setDisabled: setDisabled, open: open, close: close})
+  $.extend(this, {view: view, setValue: setValue, setDisabled: setDisabled })
 }

--- a/javascript/output_container.js
+++ b/javascript/output_container.js
@@ -1,6 +1,6 @@
 var OutputContainer = function(options){
   options = $.extend({}, options)
-  var view         = $('<span class="selected_text_container" tabindex="0"></span>')
+  var view         = $('<span class="selected_text_container" aria-expanded="false" aria-haspopup="listbox" role="combobox" tabindex="0"></span>')
   var selectedText = $('<span class="selected_text"></span>').appendTo(view)
   var selectCaret  = $('<span class="select_caret"></span>').appendTo(view).html(options.selectCaret)
 
@@ -9,6 +9,13 @@ var OutputContainer = function(options){
   setValue()
 
   // HELPER FUNCTIONS
+  function open() {
+    view.attr('aria-expanded', true)
+  }
+
+  function close() {
+    view.attr('aria-expanded', false)
+  }
 
   function setValue(value){
     selectedText.text(value || String.fromCharCode(160)); // Insert value or &nbsp;
@@ -22,5 +29,5 @@ var OutputContainer = function(options){
 
   // PUBLIC INTERFACE
 
-  $.extend(this, {view: view, setValue: setValue, setDisabled: setDisabled})
+  $.extend(this, {view: view, setValue: setValue, setDisabled: setDisabled, open: open, close: close})
 }

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -79,15 +79,14 @@ var UberSearch = function(data, options){
 
   $(view).on('setHighlight', function(event, result, index) {
     if (index < 0 && options.search) {
-      outputContainer.view.attr("aria-activedescendant", "")
+      setOutputContainerAria("aria-activedescendant", "")
       $(searchField.input).focus()
     } else if (index < 0) {
-      outputContainer.view.attr("aria-activedescendant", "")
+      setOutputContainerAria("aria-activedescendant", "")
       $(outputContainer.view).focus()
     } else {
-      outputContainer.view.attr("aria-activedescendant", result.id)
+      setOutputContainerAria("aria-activedescendant", result.id)
     }
-
   })
 
   $(view).on('inputDownArrow', function(event) {
@@ -128,7 +127,7 @@ var UberSearch = function(data, options){
 
   // When the pane is opened
   $(pane).on('shown', function(){
-    outputContainer.view.attr('aria-expanded', true)
+    setOutputContainerAria('aria-expanded', true)
     search.clear()
     markSelected(true)
     view.addClass('open')
@@ -142,7 +141,7 @@ var UberSearch = function(data, options){
 
   // When the pane is hidden
   $(pane).on('hidden', function(){
-    outputContainer.view.attr('aria-expanded', false)
+    setOutputContainerAria('aria-expanded', false)
     view.removeClass('open')
     view.focus()
   })
@@ -416,6 +415,10 @@ var UberSearch = function(data, options){
 
   function resultsCount(){
     return search.getResults().length
+  }
+
+  function setOutputContainerAria() {
+    outputContainer.view.attr.apply(outputContainer.view, arguments)
   }
 
   // returns true if the event originated outside this component

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -35,12 +35,10 @@ var UberSearch = function(data, options){
   var context          = this
   var view             = $('<span class="uber_select"></span>')
   var selectedValue    = options.value // Internally selected value
-  var outputContainer  = options.outputContainer || new OutputContainer({selectCaret: options.selectCaret})
+  var outputContainer  = options.outputContainer || new OutputContainer({selectCaret: options.selectCaret, ariaLabel: options.ariaLabel})
   var resultsContainer = $('<div class="results_container"></div>')
   var messages         = $('<div class="messages"></div>')
   var pane             = new Pane()
-
-  if (options.ariaLabel) { view.attr("aria-label", options.ariaLabel) }
 
   var searchField = new SearchField({
       placeholder: options.searchPlaceholder,

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -124,6 +124,7 @@ var UberSearch = function(data, options){
 
   // When the pane is opened
   $(pane).on('shown', function(){
+    outputContainer.open()
     search.clear()
     markSelected(true)
     view.addClass('open')
@@ -137,6 +138,7 @@ var UberSearch = function(data, options){
 
   // When the pane is hidden
   $(pane).on('hidden', function(){
+    outputContainer.close()
     view.removeClass('open')
     view.focus()
   })

--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -340,10 +340,11 @@ var UberSearch = function(data, options){
     var selected = getSelection()
     var results = search.getResults()
 
-    $(results).filter('.selected').not(selected).removeClass('selected')
+    $(results).filter('.selected').not(selected).removeClass('selected').attr('aria-selected', false)
 
     // Ensure the selected result is unhidden
     $(selected).addClass('selected').removeClass('hidden')
+    $(selected).attr('aria-selected', true)
 
     if (selected) {
       search.highlightResult(selected, { focus: focus })


### PR DESCRIPTION
Further improvements to the accessibility of uber_select: 
- Because the listbox is not always visible, it is probably better to use a combobox. This also allows us to inform the user if the select is open (expanded) or closed. Reference: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/#ex_label
- Inform screenreaders that original select is hidden
- Fix the aria-selected attribute. Selected means the option has been selected. It is not considered selected when it is highlighted.