### PR TITLE
fix: handle ENTER press without propagation

### DIFF
--- a/javascript/uber_search.js
+++ b/javascript/uber_search.js
@@ -89,8 +89,11 @@
       } else if (index < 0) {
         setOutputContainerAria("aria-activedescendant", "")
         $(outputContainer.view).focus()
-      } else {
+      } else if (result) {
+        // Check if result exists (e.g., when pressing down on the last item, result will be undefined)
         setOutputContainerAria("aria-activedescendant", result.id)
+      } else {
+        setOutputContainerAria("aria-activedescendant", "")
       }
     })
 

--- a/javascript/uber_search/list.js
+++ b/javascript/uber_search/list.js
@@ -124,6 +124,8 @@
       return results().filter('.highlighted')
     }
 
+    this.highlightedResult = highlightedResult
+
     function selectableResults(){
       return visibleResults().not('.disabled')
     }

--- a/javascript/uber_search/search.js
+++ b/javascript/uber_search/search.js
@@ -63,8 +63,6 @@
       
       if (highlightedResult.length) {
         highlightedResult.click()
-      } else {
-        $(queryInput).trigger('noHighlightSubmit')
       }
     })
 

--- a/javascript/uber_search/search.js
+++ b/javascript/uber_search/search.js
@@ -57,6 +57,17 @@
       $(context).trigger('inputDownArrow')
     })
 
+    // Handle ENTER key in search input
+    $(queryInput).on('querySubmit', function() {
+      var highlightedResult = list.view.find('.result.highlighted')
+      
+      if (highlightedResult.length) {
+        highlightedResult.click()
+      } else {
+        $(queryInput).trigger('noHighlightSubmit')
+      }
+    })
+
     $(model).on('resultsUpdated', function(){
       context.renderResults()
     })

--- a/javascript/uber_search/search.js
+++ b/javascript/uber_search/search.js
@@ -59,7 +59,7 @@
 
     // Handle ENTER key in search input
     $(queryInput).on('querySubmit', function() {
-      var highlightedResult = list.view.find('.result.highlighted')
+      var highlightedResult = list.highlightedResult()
       
       if (highlightedResult.length) {
         highlightedResult.click()

--- a/javascript/uber_search/search_field.js
+++ b/javascript/uber_search/search_field.js
@@ -45,8 +45,6 @@
 
     input.on('keydown', function(event){
       if (event.which == 13){ // When the enter button is pressed
-        event.preventDefault();
-        event.stopPropagation();
         triggerEvent('querySubmit')
         return false;
       }

--- a/javascript/uber_search/search_field.js
+++ b/javascript/uber_search/search_field.js
@@ -43,10 +43,12 @@
       triggerEvent('clear')
     })
 
-    // When the enter button is pressed
     input.on('keydown', function(event){
-      if (event.which == 13){
+      if (event.which == 13){ // When the enter button is pressed
+        event.preventDefault();
+        event.stopPropagation();
         triggerEvent('querySubmit')
+        return false;
       }
 
       if (event.which == 38) { // Up Arrow

--- a/test.html
+++ b/test.html
@@ -259,6 +259,20 @@
   <p>This example has an option with a <code>title</code> attribute that should show as a tooltip.</p>
 </span>
 
+<span class="example">
+  <label for="select">
+  Form ENTER handling (should not submit form)
+  </label>
+  <form onsubmit="alert('Form submitted! This should NOT happen when pressing ENTER in the search field.'); return false;">
+    <select placeholder="Choose a gender">
+      <option></option>
+      <option>male</option>
+      <option>female</option>
+    </select>
+    <button type="submit">Submit Form</button>
+  </form>
+</span>
+
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="javascript/uber_search.js"></script>
 <script src="javascript/uber_search/search_field.js"></script>


### PR DESCRIPTION
Don't let ENTER key press populate to a `<form>` above in the component tree.